### PR TITLE
Underline links in content

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -35,6 +35,10 @@ h1.project-name {
   }
 }
 
+a {
+  text-decoration: underline;
+}
+
 .page-header {
 
   @include large {
@@ -74,8 +78,8 @@ ul.post-list {
     }
 
     a{
-      text-decoration: none;
       color: $body-text-color;
+      text-decoration: none;
     }
     time {
       color: $body-light-text-color;
@@ -93,6 +97,10 @@ footer nav {
   padding-bottom: 1rem;
   a {
     margin-right: 1rem;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
     &:last-child {
       margin-right: 0;
     }
@@ -115,9 +123,9 @@ nav.social {
       vertical-align: middle;
       a {
         color: $body-light-text-color;
+        text-decoration: none;
         &:hover {
           color: $body-link-color;
-          text-decoration: none;
         }
       }
     }


### PR DESCRIPTION
Was going to try for full on https://brutalist-web.design/ treatment of links, but didn't like the aesthetic of underlines on things that seem obviously clickable to me (list of posts, footer nav, link to home page in main header.) However, those special elements react on hover and content in a page or post will now always be underlined.